### PR TITLE
add --config.interactive=false

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ So instead of running
 
 You can run 
 
-    $ docker run -ti -v `pwd`:/srv marmelab/bower bash -c 'bower --allow-root install'
+    $ docker run -ti -v `pwd`:/srv marmelab/bower bash -c "bower --allow-root --config.interactive=false install [package name]"
 
 The entrypoint is voluntarily omitted to ease user manipulation in the container in order to have bower generate files with the correct user rights.


### PR DESCRIPTION
Add --config.interactive=false to disable `[?] May bower anonymously report usage statistics to improve the tool over time? No/n)` question when running the bower install. Reference: http://stackoverflow.com/a/22639444/141177

Add [package name] placeholder.
